### PR TITLE
Fix Blast bond generation

### DIFF
--- a/sdk/extensions/authoring/source/NvBlastExtApexSharedParts.cpp
+++ b/sdk/extensions/authoring/source/NvBlastExtApexSharedParts.cpp
@@ -31,6 +31,7 @@
 #include "PxMat44.h"
 #include "PxBounds3.h"
 #include "PxFoundation.h"
+#include "PxPhysics.h"
 #include "PsVecMath.h"
 #include <vector>
 
@@ -821,11 +822,23 @@ Status Collide(const Vec3V& initialDir, const ConvexV& convexA, const Mat34V& bT
 	return Status(BAllEq(bCon, bTrue) == 1 ? STATUS_CONTACT : STATUS_DEGENERATE);
 }
 
-static void _calcSeparation(const ConvexV& convexA, const physx::PxTransform& aToWorldIn, const Mat34V& bToA, ConvexV& convexB, Output& out, Separation& sep)
+static void _calcSeparation(const ConvexV& convexA, const physx::PxTransform& aToWorldIn, const Mat34V& bToA, ConvexV& convexB, const Vec3V& centroidAToB, Output& out, Separation& sep)
 {
 	
 	Mat33V aToB = M34Trnsps33(bToA);
 	Vec3V normalA = out.getNormal();
+	FloatV vEpsilon = FLoad(1e-6f);
+	if (BAllEqFFFF(FIsGrtr(out.mDistSq, vEpsilon)))
+	{
+		if (BAllEqTTTT(FIsGrtr(V3Dot(centroidAToB, centroidAToB), vEpsilon)))
+		{
+			normalA = V3Normalize(centroidAToB);
+		}
+		else
+		{
+			normalA = V3UnitX();
+		}
+	}
 
 	convexA.calcExtent(normalA, sep.min0, sep.max0);
 	Vec3V normalB = M33MulV3(aToB, normalA);
@@ -972,9 +985,16 @@ bool importerHullsInProximityApexFree(uint32_t hull0Count, const PxVec3* hull0, 
 	convexB.mNumAovVertices = numAov1;
 	convexB.mAovVertices = verts1;
 
+	const physx::PxVec3 hullACenter = hull0Bounds.getCenter();
+	const physx::PxVec3 hullBCenter = hull1Bounds.getCenter();
+	const Vec3V centroidA = V3LoadU(&hullACenter.x);
+	const Vec3V centroidB = M34MulV3(bToA, V3LoadU(&hullBCenter.x));
+
 	// Take the origin of B in As space as the inital direction as it is 'the difference in transform origins B-A in A's space'
 	// Should be a good first guess
-	const Vec3V initialDir = bToA.col3;
+	// Use centroid information
+	const Vec3V initialDir = V3Sub(centroidB, centroidA);
+
 	Output output;
 	Status status = Collide(initialDir, convexA, bToA, convexB, output);
 
@@ -999,7 +1019,7 @@ bool importerHullsInProximityApexFree(uint32_t hull0Count, const PxVec3* hull0, 
 	{
 		if (separation)
 		{
-			_calcSeparation(convexA, localToWorldRT0In, bToA, convexB, output, *separation);
+			_calcSeparation(convexA, localToWorldRT0In, bToA, convexB, initialDir, output, *separation);
 		}
 		return true;
 	}
@@ -1008,7 +1028,7 @@ bool importerHullsInProximityApexFree(uint32_t hull0Count, const PxVec3* hull0, 
 	{
 		if (separation)
 		{
-			_calcSeparation(convexA, localToWorldRT0In, bToA, convexB, output, *separation);
+			_calcSeparation(convexA, localToWorldRT0In, bToA, convexB, initialDir, output, *separation);
 		}
 		PxF32 val;
 		FStore(output.mDistSq, &val);

--- a/sdk/extensions/authoring/source/NvBlastExtTriangleProcessor.cpp
+++ b/sdk/extensions/authoring/source/NvBlastExtTriangleProcessor.cpp
@@ -216,7 +216,7 @@ void TriangleProcessor::buildConvexHull(std::vector<PxVec3>& points, std::vector
 	int lastUnique = 0;
 	for (uint32_t i = 1; i < points.size(); ++i)
 	{
-		PxVec3 df = points[i] - points[lastUnique];
+		PxVec3 df = (points[i] - points[lastUnique]).abs();
 		if (df.x > V_COMP_EPS || df.y > V_COMP_EPS || df.z > V_COMP_EPS)
 		{
 			points[++lastUnique] = points[i];
@@ -237,7 +237,7 @@ void TriangleProcessor::buildConvexHull(std::vector<PxVec3>& points, std::vector
 	{
 		PxVec2 pnt = getProjectedPointWithWinding(points[i], projectionDirection);
 		PxVec2 vec = pnt - getProjectedPointWithWinding(convexHull.back(), projectionDirection);
-		if (vec.x < V_COMP_EPS && vec.y < V_COMP_EPS)
+		if (PxAbs(vec.x) < V_COMP_EPS && PxAbs(vec.y) < V_COMP_EPS)
 		{
 			continue;
 		}


### PR DESCRIPTION
There were two issues:
1) if a coincident point was found between
two convex hulls, there would be a nan normal for the bond,
which would cause it to be rejected, and
2) generating a convex hull to determine area of the bond
could be zero due to missing absolutes in the epsilon checks.