### PR TITLE
Fix invalid pointer access in authoring tools

### DIFF
--- a/sdk/extensions/authoring/source/NvBlastExtAuthoringMeshCleanerImpl.cpp
+++ b/sdk/extensions/authoring/source/NvBlastExtAuthoringMeshCleanerImpl.cpp
@@ -1558,7 +1558,11 @@ Mesh* MeshCleanerImpl::cleanMesh(const Mesh* mesh)
 		}
 	}
 
-	trque.push(best);
+	if (!trs.empty())
+	{
+		trque.push(best);
+	}
+
 	while (!trque.empty())
 	{
 		int32_t trid      = trque.front();

--- a/sdk/extensions/exporter/source/NvBlastExtExporterFbxReader.cpp
+++ b/sdk/extensions/exporter/source/NvBlastExtExporterFbxReader.cpp
@@ -198,9 +198,9 @@ void FbxFileReader::loadFromFile(const char* filename)
 	bool bAllTriangles = mesh->IsTriangleMesh();
 	if (!bAllTriangles)
 	{
-		//It creates corrupted mesh and return true. Disable it to prevent crash.
 		//try letting the FBX SDK triangulate it
-		//bAllTriangles = geoConverter.Triangulate(mesh, true) && mesh->IsTriangleMesh();
+		mesh = FbxCast<FbxMesh>(geoConverter.Triangulate(mesh, true));
+		bAllTriangles = mesh->IsTriangleMesh();
 	}
 
 	int polyCount = mesh->GetPolygonCount();


### PR DESCRIPTION
Fixes two crashes:
1) The AuthoringMeshCleaner could access the trs vector even if it was empty
2) The FBXFileReader would not properly cast the mesh object returned
from trying to triangulate the mesh