### PR TITLE
Fix asset joint serialization

### DIFF
--- a/sdk/extensions/serialization/source/DTO/TkAssetJointDescDTO.cpp
+++ b/sdk/extensions/serialization/source/DTO/TkAssetJointDescDTO.cpp
@@ -39,6 +39,7 @@ bool TkAssetJointDescDTO::serialize(Nv::Blast::Serialization::TkAssetJointDesc::
 {
 	kj::ArrayPtr<const uint32_t> nodeIndices(poco->nodeIndices, 2);
 	builder.setNodeIndices(nodeIndices);
+	builder.initAttachPositions(2);
 
 	for (int i = 0; i < 2; i++)
 	{


### PR DESCRIPTION
Minor fix to serialization of Tk Asset joints.

Currently it triggers an error since the attach position are not initialized.