### PR TITLE
Fix index out of bounds

### DIFF
--- a/sdk/toolkit/source/NvBlastTkGroupImpl.cpp
+++ b/sdk/toolkit/source/NvBlastTkGroupImpl.cpp
@@ -293,9 +293,9 @@ bool TkGroupImpl::removeActor(TkActor& actor)
 	{
 		uint32_t index = tkActor.m_groupJobIndex;
 		tkActor.m_groupJobIndex = invalidIndex<uint32_t>();
-		m_jobs.replaceWithLast(index);
 		if (index < m_jobs.size())
 		{
+			m_jobs.replaceWithLast(index);
 			NVBLAST_ASSERT(m_jobs[index].m_tkActor->m_groupJobIndex == m_jobs.size());
 			NVBLAST_ASSERT(m_jobs[index].m_tkActor->isPending());
 			m_jobs[index].m_tkActor->m_groupJobIndex = index;


### PR DESCRIPTION
Unsafe access to the array, we have encountered assert being triggered in `.replaceWithLast()` in some scenarios.