### PR TITLE
Remove mention of removed blast tool from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,6 @@ Blast tools and sample executables, along with all necessary supporting librarie
 [blast_tools_and_samples-windows.zip](blast_tools_and_samples-windows.zip) file.  This allows someone without a development environment to use these
 applications.
 
-BlastTool-1.1 (Windows 64-bit only)
------------------------------------
-
-BlastTool is a standalone GUI application for authoring Blast assets.  It imports fbx graphics files and exports Blast assets in the low-level, high-level (Tk),
-and ExtPx formats, along with fractured meshes and (optionally) collision geometry in a separate file or embedded in an fbx along with the graphics meshes.
-It is now included in [blast_tools_and_samples-windows.zip](blast_tools_and_samples-windows.zip) (see above).  Run BlastTool.Profile.win64.exe in the bin/vc15win64-cmake folder.
-
-Documentation may be found here: https://docs.nvidia.com/gameworks/content/gameworkslibrary/blast/1.1/authoring_docs/index.html
-
 Unreal Engine 4 Plugin
 ----------------------
 


### PR DESCRIPTION
For some reason, the artist tool was removed a while back. The README still mentions this tool which is not in the ZIP anymore.